### PR TITLE
fix: refine external plugin config path

### DIFF
--- a/cmd/ticommunitytars/main.go
+++ b/cmd/ticommunitytars/main.go
@@ -51,7 +51,7 @@ func gatherOptions() options {
 	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	fs.StringVar(&o.pluginConfig, "plugin-config", "/etc/plugins/plugins.yaml", "Path to plugin config file.")
 	fs.StringVar(&o.externalPluginsConfig, "external-plugins-config",
-		"/etc/plugins/external_plugins_config.yaml", "Path to external plugin config file.")
+		"/etc/external_plugins_config/external_plugins_config.yaml", "Path to external plugin config file.")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	fs.DurationVar(&o.updatePeriod, "update-period", time.Minute*30, "Period duration for periodic scans of all PRs.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac",


### PR DESCRIPTION
Part of https://github.com/tidb-community-bots/ti-community-prow/issues/147