### PR TITLE
chore: remove label workflow

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,4 +15,3 @@
   - [label_sync](./tools/label_sync.md)
 - [Workflows](./workflows.md)
   - [PR workflow](./workflows/pr.md)
-  - [Label workflow](./workflows/label.md)

--- a/docs/src/workflows/label.md
+++ b/docs/src/workflows/label.md
@@ -1,1 +1,0 @@
-# Label workflow


### PR DESCRIPTION
Because I think maybe the label process cannot be a workflow.